### PR TITLE
fix: build headers object taking care of multivalue

### DIFF
--- a/gravitee-echo-api/src/main/java/io/gravitee/sample/api/echo/EchoHandler.java
+++ b/gravitee-echo-api/src/main/java/io/gravitee/sample/api/echo/EchoHandler.java
@@ -55,7 +55,17 @@ public class EchoHandler implements Handler<RoutingContext> {
 
             //headers
             JsonObject headers = new JsonObject();
-            request.headers().forEach(entry -> headers.put(entry.getKey(), entry.getValue()));
+            request
+                .headers()
+                .entries()
+                .forEach(entry -> {
+                    String value = entry.getValue();
+                    if (headers.containsKey(entry.getKey())) {
+                        value = String.join(",", String.valueOf(headers.getValue(entry.getKey())), value);
+                    }
+                    headers.put(entry.getKey(), value);
+                });
+
             content.put("headers", headers);
 
             //query params


### PR DESCRIPTION
**Issue**

Discovered working on 
https://github.com/gravitee-io/issues/issues/7812

**Description**

The request's headers are stored in a multimap, meaning we can have multiple values for one key.

Before this fix, the way we iterate to build our response object was doing simple `Map.put` for each entries, so in case of multiple values, only the last was written:

Here is an example with the `firstName` header:

![image](https://user-images.githubusercontent.com/47851994/174230846-d556fce1-6e6b-4393-8a5b-93222719672d.png)

With the fix, we now join the headers with a comma `,`:

![image](https://user-images.githubusercontent.com/47851994/174230822-518bdc9e-87ba-4295-85fc-1c7a6c23d7fa.png)

