### PR TITLE
feat(ai): add /ai/llm fake API with Anthropic and OpenAI response formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Some apis to play with Gravitee.io
 * [gravitee-echo-api](./gravitee-echo-api/README.md)
 * [gravitee-whattimeisit-api](./gravitee-whattimeisit-api/README.md)
 * [gravitee-whoami-api](./gravitee-whoami-api/README.md)
+* [gravitee-ai-api](./gravitee-ai-api/README.md)

--- a/gravitee-ai-api/README.md
+++ b/gravitee-ai-api/README.md
@@ -1,0 +1,79 @@
+# AI API
+
+Fake LLM API that returns provider-shaped responses, useful for testing Gravitee AI gateway policies without hitting a real provider.
+
+## How to run
+`$ java -jar gravitee-sample-api-VERSION.jar <port>`
+
+`port` is optional. Default `8080`
+
+## How to use
+
+### `GET /ai/llm` / `POST /ai/llm`
+
+Returns a fake LLM completion response shaped after the target provider's format.
+
+* query params:
+  * `provider`: the provider format to simulate. `anthropic` (default) or `openai`
+  * `model`: override the model name in the response. Default: `claude-opus-4-5` (Anthropic) or `gpt-4o` (OpenAI)
+  * `latency`: artificial response delay in milliseconds. Default `0`
+  * `statusCode`: the return status code. Default `200`
+
+## Samples
+
+### Anthropic (default)
+```
+$ curl "http://localhost:8080/ai/llm"
+
+{
+  "id" : "msg_982983dd0e15472ca0cecb01",
+  "type" : "message",
+  "role" : "assistant",
+  "content" : [ {
+    "type" : "text",
+    "text" : "This is a simulated LLM response from the Gravitee sample API. Use it to test your AI gateway configuration without hitting a real provider."
+  } ],
+  "model" : "claude-opus-4-5",
+  "stop_reason" : "end_turn",
+  "stop_sequence" : null,
+  "usage" : {
+    "input_tokens" : 25,
+    "output_tokens" : 42
+  }
+}
+```
+
+### OpenAI
+```
+$ curl "http://localhost:8080/ai/llm?provider=openai"
+
+{
+  "id" : "chatcmpl-ba6365a085d34b60a3f6e5f0",
+  "object" : "chat.completion",
+  "created" : 1780554629,
+  "model" : "gpt-4o",
+  "choices" : [ {
+    "index" : 0,
+    "message" : {
+      "role" : "assistant",
+      "content" : "This is a simulated LLM response from the Gravitee sample API. Use it to test your AI gateway configuration without hitting a real provider."
+    },
+    "finish_reason" : "stop"
+  } ],
+  "usage" : {
+    "prompt_tokens" : 25,
+    "completion_tokens" : 42,
+    "total_tokens" : 67
+  }
+}
+```
+
+### Custom model + simulated latency
+```
+$ curl "http://localhost:8080/ai/llm?provider=openai&model=gpt-4o-mini&latency=500"
+```
+
+### Simulate a rate limit error
+```
+$ curl "http://localhost:8080/ai/llm?statusCode=429"
+```

--- a/gravitee-ai-api/pom.xml
+++ b/gravitee-ai-api/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.sample.api</groupId>
+        <artifactId>gravitee-sample-apis</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-ai-api</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Gravitee.io - AI API</name>
+</project>

--- a/gravitee-ai-api/src/main/java/io/gravitee/sample/api/ai/LlmHandler.java
+++ b/gravitee-ai-api/src/main/java/io/gravitee/sample/api/ai/LlmHandler.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.sample.api.ai;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Fake LLM API handler that returns provider-shaped responses (Anthropic, OpenAI).
+ *
+ * Query params:
+ *   provider   = anthropic (default) | openai
+ *   model      = override model name
+ *   latency    = artificial latency in ms (default 0)
+ *   statusCode = override HTTP status code (default 200)
+ */
+public class LlmHandler implements Handler<RoutingContext> {
+
+    private static final String PROVIDER_ANTHROPIC = "anthropic";
+    private static final String PROVIDER_OPENAI = "openai";
+
+    private static final String DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-5";
+    private static final String DEFAULT_OPENAI_MODEL = "gpt-4o";
+
+    private static final String FAKE_RESPONSE_TEXT =
+        "This is a simulated LLM response from the Gravitee sample API. " +
+        "Use it to test your AI gateway configuration without hitting a real provider.";
+
+    @Override
+    public void handle(final RoutingContext routingContext) {
+        final HttpServerRequest request = routingContext.request();
+
+        String provider = request.getParam("provider");
+        if (provider == null || provider.isBlank()) {
+            provider = PROVIDER_ANTHROPIC;
+        }
+
+        int statusCode = 200;
+        if (request.getParam("statusCode") != null) {
+            try {
+                statusCode = Integer.parseInt(request.getParam("statusCode"));
+            } catch (NumberFormatException ignored) {}
+        }
+
+        long latency = 0;
+        if (request.getParam("latency") != null) {
+            try {
+                latency = Long.parseLong(request.getParam("latency"));
+            } catch (NumberFormatException ignored) {}
+        }
+
+        final String resolvedProvider = provider;
+        final int resolvedStatusCode = statusCode;
+        final long resolvedLatency = latency;
+
+        request.endHandler(v -> {
+            if (resolvedLatency > 0) {
+                routingContext
+                    .vertx()
+                    .setTimer(resolvedLatency, id -> sendResponse(routingContext, request, resolvedProvider, resolvedStatusCode));
+            } else {
+                sendResponse(routingContext, request, resolvedProvider, resolvedStatusCode);
+            }
+        });
+    }
+
+    private void sendResponse(RoutingContext ctx, HttpServerRequest request, String provider, int statusCode) {
+        HttpServerResponse response = ctx.response();
+        JsonObject body;
+
+        switch (provider.toLowerCase()) {
+            case PROVIDER_OPENAI:
+                body = buildOpenAiResponse(request);
+                break;
+            case PROVIDER_ANTHROPIC:
+            default:
+                body = buildAnthropicResponse(request);
+                break;
+        }
+
+        response.putHeader("content-type", "application/json").setStatusCode(statusCode).end(body.encodePrettily());
+    }
+
+    private JsonObject buildAnthropicResponse(HttpServerRequest request) {
+        String model = request.getParam("model");
+        if (model == null || model.isBlank()) {
+            model = DEFAULT_ANTHROPIC_MODEL;
+        }
+
+        JsonObject contentBlock = new JsonObject().put("type", "text").put("text", FAKE_RESPONSE_TEXT);
+
+        JsonObject usage = new JsonObject().put("input_tokens", 25).put("output_tokens", 42);
+
+        return new JsonObject()
+            .put("id", "msg_" + shortUuid())
+            .put("type", "message")
+            .put("role", "assistant")
+            .put("content", new JsonArray().add(contentBlock))
+            .put("model", model)
+            .put("stop_reason", "end_turn")
+            .put("stop_sequence", (Object) null)
+            .put("usage", usage);
+    }
+
+    private JsonObject buildOpenAiResponse(HttpServerRequest request) {
+        String model = request.getParam("model");
+        if (model == null || model.isBlank()) {
+            model = DEFAULT_OPENAI_MODEL;
+        }
+
+        JsonObject message = new JsonObject().put("role", "assistant").put("content", FAKE_RESPONSE_TEXT);
+
+        JsonObject choice = new JsonObject().put("index", 0).put("message", message).put("finish_reason", "stop");
+
+        JsonObject usage = new JsonObject().put("prompt_tokens", 25).put("completion_tokens", 42).put("total_tokens", 67);
+
+        return new JsonObject()
+            .put("id", "chatcmpl-" + shortUuid())
+            .put("object", "chat.completion")
+            .put("created", Instant.now().getEpochSecond())
+            .put("model", model)
+            .put("choices", new JsonArray().add(choice))
+            .put("usage", usage);
+    }
+
+    private String shortUuid() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 24);
+    }
+}

--- a/gravitee-sample-api/pom.xml
+++ b/gravitee-sample-api/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>gravitee-whoami-api</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.sample.api</groupId>
+            <artifactId>gravitee-ai-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-sample-api/src/main/java/io/gravitee/sample/api/SampleApi.java
+++ b/gravitee-sample-api/src/main/java/io/gravitee/sample/api/SampleApi.java
@@ -18,6 +18,7 @@ package io.gravitee.sample.api;
 import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
 
+import io.gravitee.sample.api.ai.LlmHandler;
 import io.gravitee.sample.api.echo.EchoHandler;
 import io.gravitee.sample.api.whattimeisit.WhatTimeIsItHandler;
 import io.gravitee.sample.api.whoami.WhoAmIHandler;
@@ -47,6 +48,8 @@ public class SampleApi {
         router.route("/whoami").method(GET).produces("application/json").handler(new WhoAmIHandler());
 
         router.route("/whattimeisit").method(GET).produces("application/json").handler(new WhatTimeIsItHandler());
+
+        router.route("/ai/llm").method(GET).method(POST).produces("application/json").handler(new LlmHandler());
 
         int port = 8080;
         if (args.length > 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>gravitee-echo-api</module>
         <module>gravitee-whattimeisit-api</module>
         <module>gravitee-whoami-api</module>
+        <module>gravitee-ai-api</module>
         <module>gravitee-sample-api</module>
     </modules>
 


### PR DESCRIPTION
## Description

Adds a new `gravitee-ai-api` module exposing a `/ai/llm` endpoint that returns fake LLM completion responses shaped after real provider formats (Anthropic, OpenAI).

Useful for testing Gravitee AI gateway policies (LLM policy, rate limiting on tokens, provider routing) without needing real API keys or hitting live endpoints.

**Supported query params:**
| Param | Values | Default |
|---|---|---|
| `provider` | `anthropic` \| `openai` | `anthropic` |
| `model` | any string | `claude-opus-4-5` / `gpt-4o` |
| `latency` | ms | `0` |
| `statusCode` | HTTP status | `200` |

**Examples:**
```
GET /ai/llm                                     → Anthropic format
GET /ai/llm?provider=openai                     → OpenAI format
GET /ai/llm?provider=openai&model=gpt-4o-mini   → custom model
GET /ai/llm?latency=500                         → simulated latency
GET /ai/llm?statusCode=429                      → simulated rate limit
```